### PR TITLE
Add localPath option to client initialization

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,15 +9,27 @@ import { type Client } from "./types/client"
 
 interface APIOptions {
   apiKey: string
-  hostname?: string
   repositoryOwner: string
   repositoryName: string
+  /**
+   * For local development. You can pass the URL to an alternative Lekko config
+   * server (e.g. using @lekko/node-server-sdk).
+   */
+  hostname?: string
+  /**
+   * For local development to use with a Lekko config server (e.g. using
+   * @lekko/node-server-sdk) which is set to use a local repository.
+   * The target server should use this path to read from a config repository
+   * on local disk. If localPath is omitted, a default location will be used.
+   */
+  localPath?: string
 }
 
 function initAPIClient(options: APIOptions): Client {
   const transport = new ClientTransportBuilder({
     hostname: options.hostname ?? "https://app.lekko.com/api/",
     apiKey: options.apiKey,
+    localPath: options.localPath,
   }).build()
   return new TransportClient(
     options.repositoryOwner,

--- a/src/transport-builder.ts
+++ b/src/transport-builder.ts
@@ -1,12 +1,19 @@
 import { createGrpcWebTransport } from "@bufbuild/connect-web"
 
-import { type Transport } from "@bufbuild/connect"
+import { type Transport, type Interceptor } from "@bufbuild/connect"
 
-const APIKEY_INTERCEPTOR =
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (apiKey?: string) => (next: any) => async (req: any) => {
+const APIKEY_INTERCEPTOR: (apiKey?: string) => Interceptor =
+  (apiKey?: string) => (next) => async (req) => {
     if (apiKey !== undefined) {
       req.header.set("apikey", apiKey)
+    }
+    return next(req)
+  }
+
+const LOCAL_PATH_INTERCEPTOR: (path?: string) => Interceptor =
+  (path?: string) => (next) => async (req) => {
+    if (path !== undefined) {
+      req.header.set("localpath", path)
     }
     return next(req)
   }
@@ -14,10 +21,20 @@ const APIKEY_INTERCEPTOR =
 export class ClientTransportBuilder {
   hostname: string
   apiKey?: string
+  localPath?: string
 
-  constructor({ hostname, apiKey }: { hostname: string; apiKey?: string }) {
+  constructor({
+    hostname,
+    apiKey,
+    localPath,
+  }: {
+    hostname: string
+    apiKey?: string
+    localPath?: string
+  }) {
     this.hostname = hostname
     this.apiKey = apiKey
+    this.localPath = localPath
   }
 
   build(): Transport {
@@ -26,7 +43,10 @@ export class ClientTransportBuilder {
     }
     return createGrpcWebTransport({
       baseUrl: this.hostname,
-      interceptors: [APIKEY_INTERCEPTOR(this.apiKey)],
+      interceptors: [
+        APIKEY_INTERCEPTOR(this.apiKey),
+        LOCAL_PATH_INTERCEPTOR(this.localPath),
+      ],
     })
   }
 }


### PR DESCRIPTION
In conjunction with changes in https://github.com/lekkodev/node-server-sdk/pull/27, we want to add the ability to use the JS SDK in "local development" mode where it interacts with a locally running Lekko config server. The new `localPath` option is meant to allow the target server to reinitialize/watch the correct config repository on disk. A simple way to achieve this is by passing in this information as a part of every request header, which is done here.