### PR TITLE
Add tslib as a direct dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lekko/js-sdk",
-  "version": "0.1.0-beta-5",
+  "version": "0.1.0-beta-6",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
@@ -14,7 +14,8 @@
   "dependencies": {
     "@bufbuild/protobuf": "^1.7.2",
     "@connectrpc/connect": "^1.3.0",
-    "@connectrpc/connect-web": "^1.3.0"
+    "@connectrpc/connect-web": "^1.3.0",
+    "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@bufbuild/buf": "^1.29.0",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -18,5 +18,5 @@ export default {
     },
   ],
   plugins: [typescript(), commonjs(), nodeResolve(), terser()],
-  external: [/node_modules/, 'tslib'],
+  external: [/node_modules/, "tslib"],
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -983,6 +983,7 @@ __metadata:
     prettier: ^3.0.3
     rollup: ^4.1.4
     ts-jest: ^29.1.1
+    tslib: ^2.6.2
     typescript: ^5.2.2
   languageName: unknown
   linkType: soft
@@ -6033,7 +6034,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.5.0, tslib@npm:^2.6.0":
+"tslib@npm:^2.5.0, tslib@npm:^2.6.0, tslib@npm:^2.6.2":
   version: 2.6.2
   resolution: "tslib@npm:2.6.2"
   checksum: 329ea56123005922f39642318e3d1f0f8265d1e7fcb92c633e0809521da75eeaca28d2cf96d7248229deb40e5c19adf408259f4b9640afd20d13aecc1430f3ad


### PR DESCRIPTION
We need to add tslib as a direct dependency. This is because @rollup/plugin-typescript uses TS's importHelpers options by default and tslib is a runtime dependency that helps in deduplicating function declarations for things like async/await syntax.